### PR TITLE
Update mount_dest.sh

### DIFF
--- a/circlean_fs/root_partition/opt/groomer/mount_dest.sh
+++ b/circlean_fs/root_partition/opt/groomer/mount_dest.sh
@@ -22,15 +22,15 @@ check_not_root() {
 }
 
 check_source_exists() {
-    if [ ! -b "${SRC_DEV}" ]; then
-        echo "GROOMER: Source device (${SRC_DEV}) does not exist."
+    if [ ! -b "${SRC_DEV}1" ]; then
+        echo "GROOMER: Source device (${SRC_DEV}1) does not exist."
         exit
     fi
 }
 
 check_dest_exists() {
-    if [ ! -b "${DST_DEV}" ]; then
-        echo "GROOMER: Destination device (${DST_DEV}) does not exist."
+    if [ ! -b "${DST_DEV}1" ]; then
+        echo "GROOMER: Destination device (${DST_DEV}1) does not exist."
         exit
     fi
 }


### PR DESCRIPTION
Groomer complains Source and Destination device does not exist. "10-usb.rules" creates SYMLINK to "/dev/source_key%n" and "/dev/dest_key%n", but mount_dest.sh checks for "/dev/source_key" and "/dev/dest_key"
Solution tested on RPi4